### PR TITLE
Add widget tests for loading, error, and success states (#8)

### DIFF
--- a/test/earthquake_states_test.dart
+++ b/test/earthquake_states_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('EarthquakeApp Widget Tests', () {
+    testWidgets('Displays loading state with "Please Wait"', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(child: Text("Please Wait")),
+          ),
+        ),
+      );
+
+      expect(find.text("Please Wait"), findsOneWidget);
+    });
+
+    testWidgets('Displays error state with "Oh snap!!!!! No Internet"', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(child: Text("Oh snap!!!!! No Internet")),
+          ),
+        ),
+      );
+
+      expect(find.text("Oh snap!!!!! No Internet"), findsOneWidget);
+    });
+
+    testWidgets('Displays success state with earthquake data', (WidgetTester tester) async {
+      final List<String> mockData = ['Earthquake in Japan', 'Earthquake in California'];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ListView(
+              children: mockData.map((quake) => ListTile(title: Text(quake))).toList(),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Earthquake in Japan'), findsOneWidget);
+      expect(find.text('Earthquake in California'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds widget tests for three UI states:

-  Loading: shows "Please Wait"
-  Error: shows "Oh snap!!!!! No Internet"
-  Success: shows a mock list of earthquakes

Linked to Issue #8 – SSOC S4 contribution
