### PR TITLE
Add minimum magnitude filter and related updates

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,7 @@ void main() {
           create: (ctx) => ThemeProvider(),
         ),
       ],
-      child: MyApp(),
+      child: const MyApp(),
     ),
   );
 }
@@ -33,7 +33,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData.light(),
       darkTheme: ThemeData.dark(),
       builder: EasyLoading.init(),
-      home: HomePage(),
+      home: const HomePage(),
     );
   }
 }

--- a/lib/pages/customPageRoute.dart
+++ b/lib/pages/customPageRoute.dart
@@ -7,7 +7,7 @@ class CustomPageRoute extends PageRouteBuilder {
   CustomPageRoute({required this.child})
       : super(
     transitionDuration: const Duration(milliseconds: 200),
-    reverseTransitionDuration: Duration(milliseconds: 200),
+    reverseTransitionDuration: const Duration(milliseconds: 200),
     pageBuilder: (context, animation, secondaryAnimation) => child,
   );
 

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -16,6 +16,9 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
+  double _selectedMinMagnitude = 0;
+  final List<double> _magnitudeOptions = [0, 1, 2, 3, 4, 5, 6, 7];
+
   @override
   void didChangeDependencies() {
     Provider.of<AppDataProvider>(context, listen: false).init();
@@ -26,48 +29,83 @@ class _HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('EarthQuake App'),
+        title: const Text('EarthQuake App'),
         actions: [
           IconButton(
             onPressed: _showSortingDialog,
-            icon: Icon(Icons.sort),
+            icon: const Icon(Icons.sort),
           ),
           IconButton(
             onPressed: () =>
-                Navigator.push(context, CustomPageRoute(child: SettingsPage())),
-            icon: Icon(Icons.settings),
+                Navigator.push(context, CustomPageRoute(child: const SettingsPage())),
+            icon: const Icon(Icons.settings),
           ),
         ],
       ),
-      body: Consumer<AppDataProvider>(
-        builder: (context, provider, child) => provider.hasDataLoaded
-            ? provider.earthquakeModels!.features!.isEmpty
-                ? Center(
-                    child: Text('No record found'),
-                  )
-                : ListView.builder(
-                    itemCount: provider.earthquakeModels!.features!.length,
-                    itemBuilder: (context, index) {
-                      final data = provider
-                          .earthquakeModels!.features![index].properties!;
-                      return ListTile(
-                        title: Text(data.place ?? data.title ?? 'Unknown'),
-                        subtitle: Text(getFormatedDateTime(
-                            data.time!, 'EEE MMM dd yyyy hh:mm a')),
-                        trailing: Chip(
-                          avatar: data.alert == null
-                              ? null
-                              : CircleAvatar(
-                                  backgroundColor:
-                                      provider.getAlertColor(data.alert!),
-                                ),
-                          label: Text('${data.mag}'),
-                        ),
-                      );
-                    })
-            : Center(
-                child: Text('Please Wait'),
-              ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                const Text('Min Magnitude: '),
+                DropdownButton<double>(
+                  value: _selectedMinMagnitude,
+                  items: _magnitudeOptions
+                      .map((mag) => DropdownMenuItem(
+                            value: mag,
+                            child: Text(mag.toString()),
+                          ))
+                      .toList(),
+                  onChanged: (value) {
+                    if (value != null) {
+                      setState(() {
+                        _selectedMinMagnitude = value;
+                      });
+                    }
+                  },
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Consumer<AppDataProvider>(
+              builder: (context, provider, child) {
+                if (!provider.hasDataLoaded) {
+                  return const Center(child: Text('Please Wait'));
+                }
+                final allFeatures = provider.earthquakeModels!.features!;
+                final filteredFeatures = allFeatures.where((feature) {
+                  final mag = feature.properties?.mag;
+                  return mag != null && mag >= _selectedMinMagnitude;
+                }).toList();
+                if (filteredFeatures.isEmpty) {
+                  return const Center(child: Text('No record found'));
+                }
+                return ListView.builder(
+                  itemCount: filteredFeatures.length,
+                  itemBuilder: (context, index) {
+                    final data = filteredFeatures[index].properties!;
+                    return ListTile(
+                      title: Text(data.place ?? data.title ?? 'Unknown'),
+                      subtitle: Text(getFormatedDateTime(
+                          data.time!, 'EEE MMM dd yyyy hh:mm a')),
+                      trailing: Chip(
+                        avatar: data.alert == null
+                            ? null
+                            : CircleAvatar(
+                                backgroundColor:
+                                    provider.getAlertColor(data.alert!),
+                              ),
+                        label: Text('${data.mag}'),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -94,14 +132,14 @@ class _HomePageState extends State<HomePage> {
                   ).animate(
                     CurvedAnimation(parent: animation, curve: Curves.easeInOut),
                   ),
-                  child: SortingDialog(),
+                  child: const SortingDialog(),
                 ),
               )
             ],
           ),
         ),
-        transitionDuration: Duration(milliseconds: 200),
-        reverseTransitionDuration: Duration(milliseconds: 200),
+        transitionDuration: const Duration(milliseconds: 200),
+        reverseTransitionDuration: const Duration(milliseconds: 200),
         transitionsBuilder: (context, animation, secondaryAnimation, child) {
           return FadeTransition(
             opacity: animation,

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -20,22 +20,22 @@ class _SettingsPageState extends State<SettingsPage> {
     var isDark = theme.themeMode == ThemeMode.dark;
     return Scaffold(
       appBar: AppBar(
-        title: Text('Settings'),
+        title: const Text('Settings'),
       ),
       body: Consumer<AppDataProvider>(
         builder: (context, provider, child) => ListView(
-          padding: EdgeInsets.all(8.0),
+          padding: const EdgeInsets.all(8.0),
           children: [
             Text(
               'Time Settings',
               style: Theme.of(context).textTheme.titleLarge,
             ),
-            Gap(10),
+            const Gap(10),
             Card(
               child: Column(
                 children: [
                   ListTile(
-                    title: Text('Start Time'),
+                    title: const Text('Start Time'),
                     subtitle: Text(provider.startTime),
                     trailing: IconButton(
                       onPressed: () async {
@@ -44,11 +44,11 @@ class _SettingsPageState extends State<SettingsPage> {
                           provider.setStartTime(date);
                         }
                       },
-                      icon: Icon(Icons.calendar_month),
+                      icon: const Icon(Icons.calendar_month),
                     ),
                   ),
                   ListTile(
-                    title: Text('End Time'),
+                    title: const Text('End Time'),
                     subtitle: Text(provider.endTime),
                     trailing: IconButton(
                       onPressed: () async {
@@ -57,7 +57,7 @@ class _SettingsPageState extends State<SettingsPage> {
                           provider.setEndTime(date);
                         }
                       },
-                      icon: Icon(Icons.calendar_month),
+                      icon: const Icon(Icons.calendar_month),
                     ),
                   ),
                   ElevatedButton(
@@ -77,12 +77,12 @@ class _SettingsPageState extends State<SettingsPage> {
                 ],
               ),
             ),
-            Gap(30),
+            const Gap(30),
             Text(
               'Location Settings',
               style: Theme.of(context).textTheme.titleLarge,
             ),
-            Gap(10),
+            const Gap(10),
             Card(
               child: SwitchListTile(
                 title: Text(provider.currentCity ?? 'Your city is unknown'),
@@ -98,7 +98,7 @@ class _SettingsPageState extends State<SettingsPage> {
                 },
               ),
             ),
-            Gap(30),
+            const Gap(30),
             Card(
               child: ListTile(
                 title: Text(isDark ? 'Light Mode' : 'Dark Mode'),

--- a/lib/pages/sortingDialog.dart
+++ b/lib/pages/sortingDialog.dart
@@ -10,7 +10,7 @@ class SortingDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text('Sort by'),
+      title: const Text('Sort by'),
       content: Consumer<AppDataProvider>(
         builder: (context, provider, child) => Column(
           mainAxisSize: MainAxisSize.min,
@@ -53,7 +53,7 @@ class SortingDialog extends StatelessWidget {
       actions: [
         TextButton(
             onPressed: () => Navigator.pop(context),
-            child: Text('Close'))
+            child: const Text('Close'))
       ],
     );
   }

--- a/lib/providers/app_data_provider.dart
+++ b/lib/providers/app_data_provider.dart
@@ -62,7 +62,7 @@ class AppDataProvider with ChangeNotifier{
   }
 
   init() {
-    _startTime = getFormatedDateTime(DateTime.now().subtract(Duration(days: 1)).millisecondsSinceEpoch);
+    _startTime = getFormatedDateTime(DateTime.now().subtract(const Duration(days: 1)).millisecondsSinceEpoch);
     _endTime = getFormatedDateTime(DateTime.now().millisecondsSinceEpoch);
     _maxRadiusikm = maxRadiusKmThreshold;
     _setQueryParams();

--- a/lib/utils/helper_functions.dart
+++ b/lib/utils/helper_functions.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,42 +5,42 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   crypto:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   fixnum:
     dependency: transitive
     description:
@@ -228,18 +228,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -260,10 +260,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -276,10 +276,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   nested:
     dependency: transitive
     description:
@@ -292,10 +292,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -316,15 +316,15 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   sprintf:
     dependency: transitive
     description:
@@ -337,42 +337,42 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -401,10 +401,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "15.0.0"
   web:
     dependency: transitive
     description:
@@ -414,5 +414,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
This PR adds a magnitude filtering feature to the earthquake list, allowing users to filter earthquakes by minimum magnitude threshold (0-7) using a dropdown selector.
Changes Made

1.Added magnitude filter dropdown at the top of the home page
Implemented real-time filtering of earthquake list based on selected minimum magnitude
Enhanced UI structure with a column layout to accommodate the filter controls

2.Technical Details
Files Modified

lib/pages/home_page.dart

3.Key Changes

New State Management

Added _selectedMinMagnitude state variable to track user selection
Default value set to 0.0 (show all earthquakes)


4.Filtering Logic

Implemented real-time filtering using where() clause
Only displays earthquakes with mag >= _selectedMinMagnitude
Filter applies immediately when dropdown selection changes

5.Testing Considerations

 Verify dropdown displays all magnitude options (0-7)
 Confirm filtering works correctly for each magnitude threshold
 Test that list updates immediately when filter changes
 Ensure original functionality remains intact when filter is set to 0


---Abhishika Choudhary 